### PR TITLE
Snap-based package installs

### DIFF
--- a/roles/common/tasks/golang.yml
+++ b/roles/common/tasks/golang.yml
@@ -1,26 +1,9 @@
 ---
 - block:
-  - name: 'golang : download golang 1.12.4 archive'
-    get_url:
-      url: https://dl.google.com/go/go1.12.4.linux-amd64.tar.gz
-      dest: /tmp/golang.tar.gz
-      checksum: sha256:d7d1f1f88ddfe55840712dc1747f37a790cbcaa448f6c9cf51bbe10aa65442f5
-
-  - name: 'golang : extract archive'
-    unarchive:
-      dest: /usr/local
-      remote_src: yes
-      src: /tmp/golang.tar.gz
-
-  - name: 'golang : add golang directory to $PATH'
-    lineinfile:
-      insertafter: EOF
-      line: export PATH=$PATH:/usr/local/go/bin
-      path: '{{ item }}'
-      state: present
-    with_items:
-      - /etc/profile
-      - /etc/zsh/zprofile
+  - name: 'golang : install golang snap'
+    snap:
+      name: go
+      classic: yes
 
   - name: 'golang : setup $GOPATH'
     lineinfile:
@@ -41,11 +24,6 @@
     with_items:
       - /etc/profile
       - /etc/zsh/zprofile
-
-  - name: 'golang : cleanup fragments'
-    file:
-      dest: /tmp/golang.tar.gz
-      state: absent
 
   tags:
     - common

--- a/roles/common/tasks/node.yml
+++ b/roles/common/tasks/node.yml
@@ -1,19 +1,12 @@
 ---
 - block:
 
-  - name: 'node : download setup script'
-    get_url:
-      url: https://deb.nodesource.com/setup_10.x
-      dest: /tmp/node_setup.sh
-
-  - name: 'node : execute PPA setup script'
-    shell: bash /tmp/node_setup.sh
-
-  - name: 'node : install Node'
-    apt:
-      name: nodejs
-      state: present
-      update_cache: yes
+  - name: 'node : install LTS version with snap'
+    snap:
+      name: go
+      classic: yes
+# add the following if version 10.x is preferred to LTS
+      # channel: "10"
 
   - name: 'node : import Yarn APT key'
     apt_key:
@@ -31,11 +24,6 @@
     apt:
       name: yarn
       state: present
-
-  - name: 'node : cleanup temp files'
-    file:
-      path: /tmp/node_setup.sh
-      state: absent
 
   tags:
     - common


### PR DESCRIPTION
Moved golang and node.js to snap-based package installs, which are easier and more maintainable (and work across Ubuntu 18.04 and 20.04 etc.). Snap package versions are kept relatively fresh (more recent than apt at least). With go, it's not linked to a specific golang verison and will install latest available. For node, a specific major version can be specified with snap "channel".

Ansible snap module is available in Ansible 2.8 and up, on Ubuntu 18.04 apt package for Ansible is an older version, but a newer one can be installed with:
```
$ sudo apt install software-properties-common
$ sudo apt-add-repository --yes --update ppa:ansible/ansible
$ sudo apt install ansible
```
This only needs to be done on the host system, I believe (in case of remote provisioning).