### PR TITLE
add powershell (snap)

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -6,3 +6,4 @@
 - include: ruby.yml tags=common,ruby
 - include: node.yml tags=common,node,cookie-monster
 - include: composer.yml tags=common,composer,magescan
+- include: powershell.yml tags=common,powershell

--- a/roles/common/tasks/powershell.yml
+++ b/roles/common/tasks/powershell.yml
@@ -1,0 +1,13 @@
+---
+  - block:
+  
+    - name: 'powershell : install snap'
+      snap:
+        name: powershell
+        classic: yes
+        state: present
+    
+    tags:
+      - common
+      - powershell
+        


### PR DESCRIPTION
Add task to install Powershell as a snap package. Ansible snap module requires Ansible version 2.8, which is newer than the default apt package in Ubuntu 18.04, but can be installed with ppa: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-ansible-on-ubuntu
(only needs to be done on the Ansible host)