### PR TITLE
simplify LinEnum task

### DIFF
--- a/roles/recon/tasks/linenum.yml
+++ b/roles/recon/tasks/linenum.yml
@@ -5,28 +5,13 @@
     file:
       path: /usr/share/linux-binaries
       state: directory
-
-  - name: 'linenum : clone repository'
-    git:
-      accept_hostkey: yes
-      clone: yes
-      depth: 1
-      dest: /tmp/linenum
-      force: yes
-      repo: https://github.com/rebootuser/LinEnum.git
-
-  - name: 'linenum : copy script'
-    copy:
+  
+  - name: 'linenum : download the script'
+    get_url:
+      url: https://raw.githubusercontent.com/rebootuser/LinEnum/master/LinEnum.sh
       dest: /usr/share/linux-binaries/LinEnum.sh
-      mode: 0755
-      remote_src: yes
-      src: /tmp/linenum/LinEnum.sh
-
-  - name: 'linenum : remove fragments'
-    file:
-      path: /tmp/linenum
-      state: absent
-
+      mode: '0755'
+    
   tags:
     - recon
     - linenum


### PR DESCRIPTION
Simplify LinEnum task - no need for git clone and cleanup, can just download the single LinEnum.sh file from the master branch and save in the right place.